### PR TITLE
[INC-15] Fix `SlotList` view's table view content inset not work issue.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "JSToast",
+        "repositoryURL": "https://github.com/wlsdms0122/JSToast",
+        "state": {
+          "branch": null,
+          "revision": "021d2981603ca36c2cc56225cba24089fbf6de8b",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/wlsdms0122/JSToast", .exact("1.0.0"))
+        .package(url: "https://github.com/wlsdms0122/JSToast", .exact("2.0.0"))
     ],
     targets: [
         .target(

--- a/Sources/RunsquitoKit/Module/Common/ToastController.swift
+++ b/Sources/RunsquitoKit/Module/Common/ToastController.swift
@@ -16,9 +16,9 @@ class ToastController {
         Toaster.shared.showToast(
             Toast(ToastView(title: title)),
             withDuration: 2,
-            at: [.inside(of: .top), .center(of: .x)],
-            show: .slideIn(duration: 0.3, direction: .down),
-            hide: .fadeOut(duration: 0.3)
+            positions: [.inside(of: .top), .center(of: .x)],
+            showAnimator: .slideIn(duration: 0.3, direction: .down),
+            hideAnimator: .fadeOut(duration: 0.3)
         )
     }
 }

--- a/Sources/RunsquitoKit/Module/SlotDetail/SlotDetailViewController.swift
+++ b/Sources/RunsquitoKit/Module/SlotDetail/SlotDetailViewController.swift
@@ -126,13 +126,7 @@ final class SlotDetailViewController: UIViewController {
     }
     
     private func showToast(title: String) {
-        Toaster.shared.showToast(
-            Toast(ToastView(title: title)),
-            withDuration: 2,
-            at: [.inside(of: .top), .center(of: .x)],
-            show: .slideIn(duration: 0.3, direction: .down),
-            hide: .fadeOut(duration: 0.3)
-        )
+        ToastController.shared.showToast(title: title)
     }
 }
 

--- a/Sources/RunsquitoKit/Module/SlotList/SlotListView.swift
+++ b/Sources/RunsquitoKit/Module/SlotList/SlotListView.swift
@@ -73,14 +73,22 @@ final class SlotListView: UIView {
     }()
     
     let tableView: UITableView = {
-        let view = UITableView(frame: .zero, style: .grouped)
+        // Set table view's initial height(over content inset's top) for initial inset rendering.
+        // Code generate view with frame `.zero` conflict autolayout constraints when initial load.
+        // If you set a value above 37 as the height, inset work normally. but i don't know what the number 37 mean.
+        let view = UITableView(
+            frame: .init(
+                origin: .zero,
+                size: .init(
+                    width: 0,
+                    height: SlotListView.headerHeight * 2
+                )
+            ),
+            style: .grouped
+        )
         view.tableHeaderView = UIView(frame: .init(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
         view.contentInset.top = SlotListView.headerHeight
         view.scrollIndicatorInsets.top = SlotListView.headerHeight
-        
-        // Set content offset to (-)top content inset.
-        // because code generate table view's inset not work about initial offset of table view.
-        view.contentOffset.y = -SlotListView.headerHeight
         
         // Cell register
         view.register(SlotListTableViewCell.self, forCellReuseIdentifier: SlotListTableViewCell.name)

--- a/Sources/RunsquitoKit/Module/ValueEdit/ValueEditViewController.swift
+++ b/Sources/RunsquitoKit/Module/ValueEdit/ValueEditViewController.swift
@@ -153,13 +153,7 @@ final class ValueEditViewController: UIViewController {
     }
     
     private func showToast(title: String) {
-        Toaster.shared.showToast(
-            Toast(ToastView(title: title)),
-            withDuration: 2,
-            at: [.inside(of: .top), .center(of: .x)],
-            show: .slideIn(duration: 0.3, direction: .down),
-            hide: .fadeOut(duration: 0.3)
-        )
+        ToastController.shared.showToast(title: title)
     }
 }
 


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

When you create `View` based on code, normally frame set `.zero`.

As this time, if `view` has autolayout constraints, it occur conflict between content inset based on `frame` and autolayout calculation maybe.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Set `view`'s height appropriate value.

Exactly, set content inset + 37 work rightly. But i don't know what number 37 means.

So set approximate value like double of inset.

> \+ update `JSToast` version 2.0.0.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
